### PR TITLE
Validate uninstallation of bundle plugins

### DIFF
--- a/entity.services.yml
+++ b/entity.services.yml
@@ -9,3 +9,8 @@ services:
     class: Drupal\entity\BundlePlugin\BundlePluginInstaller
     arguments: ['@entity_type.manager', '@entity_bundle.listener', '@field_storage_definition.listener', '@field_definition.listener']
 
+  entity.bundle_plugin.uninstall_validator:
+    class: \Drupal\entity\BundlePluginUninstallValidator
+    tags:
+      - { name: module_install.uninstall_validator }
+    arguments: ['@entity_type.manager', '@string_translation']

--- a/entity.services.yml
+++ b/entity.services.yml
@@ -10,7 +10,7 @@ services:
     arguments: ['@entity_type.manager', '@entity_bundle.listener', '@field_storage_definition.listener', '@field_definition.listener']
 
   entity.bundle_plugin.uninstall_validator:
-    class: \Drupal\entity\BundlePluginUninstallValidator
+    class: \Drupal\entity\BundlePlugin\BundlePluginUninstallValidator
     tags:
       - { name: module_install.uninstall_validator }
     arguments: ['@entity_type.manager', '@string_translation']

--- a/src/BundlePlugin/BundlePluginUninstallValidator.php
+++ b/src/BundlePlugin/BundlePluginUninstallValidator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\entity;
+namespace Drupal\entity\BundlePlugin;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleUninstallValidatorInterface;

--- a/src/BundlePluginUninstallValidator.php
+++ b/src/BundlePluginUninstallValidator.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\entity;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleUninstallValidatorInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+
+class BundlePluginUninstallValidator implements ModuleUninstallValidatorInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs the object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity manager.
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   *   The string translation service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, TranslationInterface $string_translation) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($module) {
+    $reasons = [];
+
+    foreach (entity_get_bundle_plugin_entity_types() as $entity_type) {
+      /** @var \Drupal\entity\BundlePlugin\BundlePluginHandler $bundle_handler */
+      $bundle_handler = $this->entityTypeManager->getHandler($entity_type->id(), 'bundle_plugin');
+      $bundles = $bundle_handler->getBundleInfo();
+
+      // We find all bundles which have to be removed due to the uninstallation.
+      $bundles_filtered_by_module = array_filter($bundles, function ($bundle_info) use ($module) {
+        return $module === $bundle_info['provider'];
+      });
+
+      if (!empty($bundles_filtered_by_module)) {
+        $bundles_with_content = array_filter($bundles_filtered_by_module, function ($bundle_info, $bundle_id) use ($entity_type) {
+          $count = $this->entityTypeManager->getStorage($entity_type->id())->getQuery()
+            ->condition($entity_type->getKey('bundle'), $bundle_id)
+            ->count()
+            ->execute();
+          return $count > 0;
+        }, ARRAY_FILTER_USE_BOTH);
+  
+        foreach ($bundles_with_content as $bundle) {
+          $reasons[] = $this->t('There is data for the bundle @bundle on the entity type @entity_type. Please remove all content before uninstalling the module.', [
+            '@bundle' => $bundle['label'],
+            '@entity_type' => $entity_type->getLabel(),
+          ]);
+        }
+      }
+    }
+
+    return $reasons;
+  }
+
+}

--- a/src/BundlePluginUninstallValidator.php
+++ b/src/BundlePluginUninstallValidator.php
@@ -52,11 +52,11 @@ class BundlePluginUninstallValidator implements ModuleUninstallValidatorInterfac
 
       if (!empty($bundles_filtered_by_module)) {
         $bundles_with_content = array_filter($bundles_filtered_by_module, function ($bundle_info, $bundle_id) use ($entity_type) {
-          $count = $this->entityTypeManager->getStorage($entity_type->id())->getQuery()
+          $result = $this->entityTypeManager->getStorage($entity_type->id())->getQuery()
             ->condition($entity_type->getKey('bundle'), $bundle_id)
-            ->count()
+            ->range(0, 1)
             ->execute();
-          return $count > 0;
+          return !empty($result);
         }, ARRAY_FILTER_USE_BOTH);
   
         foreach ($bundles_with_content as $bundle) {

--- a/src/BundlePluginUninstallValidator.php
+++ b/src/BundlePluginUninstallValidator.php
@@ -7,11 +7,16 @@ use Drupal\Core\Extension\ModuleUninstallValidatorInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 
+/**
+ * Prevents uninstalling modules with bundle plugins in case of found data.
+ */
 class BundlePluginUninstallValidator implements ModuleUninstallValidatorInterface {
 
   use StringTranslationTrait;
 
   /**
+   * The entity type manager.
+   *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
@@ -20,7 +25,7 @@ class BundlePluginUninstallValidator implements ModuleUninstallValidatorInterfac
    * Constructs the object.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity manager.
+   *   The entity type manager.
    * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
    *   The string translation service.
    */

--- a/tests/modules/entity_module_bundle_plugin_examples_test/entity_module_bundle_plugin_examples_test.info.yml
+++ b/tests/modules/entity_module_bundle_plugin_examples_test/entity_module_bundle_plugin_examples_test.info.yml
@@ -1,0 +1,7 @@
+name: 'Entity bundle plugin examples test'
+type: module
+description: 'Module for testing bundle plugins.'
+package: Testing
+core: 8.x
+dependencies:
+  - entity

--- a/tests/modules/entity_module_bundle_plugin_examples_test/src/Plugin/BundlePluginTest/Second.php
+++ b/tests/modules/entity_module_bundle_plugin_examples_test/src/Plugin/BundlePluginTest/Second.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace Drupal\entity_module_bundle_plugin_test\Plugin\BundlePluginTest;
+namespace Drupal\entity_module_bundle_plugin_examples_test\Plugin\BundlePluginTest;
 
 use Drupal\entity\BundleFieldDefinition;
 use Drupal\Core\Plugin\PluginBase;
+use Drupal\entity_module_bundle_plugin_test\Plugin\BundlePluginTest\BundlePluginTestInterface;
 
 /**
  * Provides the second bundle plugin.


### PR DESCRIPTION
* Let's validate what happens when you uninstall a module providing a bundle plugin
* Expected behaviour: It is not possible to uninstall, unless all content for this bundle is removed
* While writing the test I realized that ```static::$modules``` doesn't actually install modules, so for example ```\entity_modules_installed``` is not triggered. I have doubts on the reliability of kernel tests now.